### PR TITLE
Removing CPUTemplate from fc-go-sdk

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -51,7 +51,6 @@ func createMachine(ctx context.Context, name string, forwardSignals []os.Signal)
 		LogLevel:        "Info",
 		MachineCfg: models.MachineConfiguration{
 			VcpuCount:   Int64(1),
-			CPUTemplate: models.CPUTemplate(models.CPUTemplateT2),
 			MemSizeMib:  Int64(256),
 			Smt:         Bool(false),
 		},

--- a/examples/cmd/snapshotting/example_demo.go
+++ b/examples/cmd/snapshotting/example_demo.go
@@ -77,7 +77,6 @@ func createNewConfig(socketPath string, opts ...configOpt) sdk.Config {
 	kernelImagePath := filepath.Join(dir, "vmlinux")
 
 	var vcpuCount int64 = 2
-	cpuTemplate := models.CPUTemplate(models.CPUTemplateT2)
 	var memSizeMib int64 = 256
 	smt := false
 
@@ -91,7 +90,6 @@ func createNewConfig(socketPath string, opts ...configOpt) sdk.Config {
 		KernelImagePath: kernelImagePath,
 		MachineCfg: models.MachineConfiguration{
 			VcpuCount:   &vcpuCount,
-			CPUTemplate: cpuTemplate,
 			MemSizeMib:  &memSizeMib,
 			Smt:         &smt,
 		},

--- a/internal/cpu_template.go
+++ b/internal/cpu_template.go
@@ -1,0 +1,71 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package internal
+
+import (
+	"bufio"
+	"io"
+	"os"
+	"regexp"
+	"runtime"
+	"sync"
+)
+
+var (
+	isIntel     bool
+	isIntelOnce sync.Once
+)
+
+// SupportCPUTemplate returns true if Firecracker supports CPU templates on
+// the current architecture.
+func SupportCPUTemplate() (bool, error) {
+	if runtime.GOARCH != "amd64" {
+		return false, nil
+	}
+
+	var err error
+	isIntelOnce.Do(func() {
+		isIntel, err = checkIsIntel()
+	})
+	return isIntel, err
+}
+
+var vendorID = regexp.MustCompile(`^vendor_id\s*:\s*(.+)$`)
+
+func checkIsIntel() (bool, error) {
+	f, err := os.Open("/proc/cpuinfo")
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+
+	id, err := findFirstVendorID(f)
+	if err != nil {
+		return false, err
+	}
+
+	return id == "GenuineIntel", nil
+}
+
+func findFirstVendorID(r io.Reader) (string, error) {
+	s := bufio.NewScanner(r)
+	for s.Scan() {
+		line := s.Text()
+		matches := vendorID.FindStringSubmatch(line)
+		if len(matches) == 2 {
+			return matches[1], nil
+		}
+	}
+	return "", nil
+}

--- a/internal/cpu_template_test.go
+++ b/internal/cpu_template_test.go
@@ -1,0 +1,41 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package internal
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindFirstVendorID(t *testing.T) {
+	cases := []struct {
+		input    string
+		vendorID string
+	}{
+		{"vendor_id : GenuineIntel", "GenuineIntel"},
+		{"vendor_id : AuthenticAMD", "AuthenticAMD"},
+
+		// aarch64 doesn't have vendor IDs.
+		{"", ""},
+	}
+	for _, c := range cases {
+		r := strings.NewReader(c.input)
+		id, err := findFirstVendorID(r)
+		require.NoError(t, err)
+		assert.Equal(t, c.vendorID, id)
+	}
+}


### PR DESCRIPTION
Signed-off-by: Vaishnavi Vejella <vvejella@amazon.com>

*Issue:*
CPU Template defines a set of flags to be disabled from the microvm so that the features exposed to the guest and works only on Intel not AMD.

*Description of changes:* Removing CPUTemplate to test the repository against AMD instance in BuildKite dashboard. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
