### PR TITLE
SendCtrlAltDel is not supported on ARM

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -108,8 +108,8 @@ steps:
   
   - label: ':book: examples'
     commands:
-      - "sudo -E PATH=$PATH FC_TEST_DATA_PATH=${FC_TEST_DATA_PATH} make -C examples/cmd/snapshotting run"
-      - "sudo -E PATH=$PATH FC_TEST_DATA_PATH=${FC_TEST_DATA_PATH} make -C examples/cmd/snapshotting clean"
+      - "sudo -E PATH=$FC_TEST_DATA_PATH:$PATH FC_TEST_DATA_PATH=${FC_TEST_DATA_PATH} make -C examples/cmd/snapshotting run"
+      - "sudo -E PATH=$FC_TEST_DATA_PATH:$PATH FC_TEST_DATA_PATH=${FC_TEST_DATA_PATH} make -C examples/cmd/snapshotting clean"
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"
       distro: "${BUILDKITE_AGENT_META_DATA_DISTRO}"
@@ -125,7 +125,7 @@ steps:
 
   - label: ':hammer: root tests'
     commands:
-      - "sudo -E PATH=$PATH FC_TEST_TAP=fc-root-tap${BUILDKITE_BUILD_NUMBER} FC_TEST_DATA_PATH=${FC_TEST_DATA_PATH} make test EXTRAGOARGS='-v -count=1 -race' DISABLE_ROOT_TESTS="
+      - "sudo -E PATH=$FC_TEST_DATA_PATH:$PATH FC_TEST_TAP=fc-root-tap${BUILDKITE_BUILD_NUMBER} FC_TEST_DATA_PATH=${FC_TEST_DATA_PATH} make test EXTRAGOARGS='-v -count=1 -race' DISABLE_ROOT_TESTS="
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"
       distro: "${BUILDKITE_AGENT_META_DATA_DISTRO}"
@@ -137,7 +137,7 @@ steps:
       FC_TEST_JAILER_BIN: "${FC_TEST_DATA_PATH}/jailer-main"
       DOCKER_IMAGE_TAG: "$BUILDKITE_BUILD_NUMBER"
     commands:
-      - "sudo -E PATH=$PATH FC_TEST_TAP=fc-mst-tap${BUILDKITE_BUILD_NUMBER} make test EXTRAGOARGS='-v -count=1 -race' DISABLE_ROOT_TESTS="
+      - "sudo -E PATH=$FC_TEST_DATA_PATH:$PATH FC_TEST_TAP=fc-mst-tap${BUILDKITE_BUILD_NUMBER} make test EXTRAGOARGS='-v -count=1 -race' DISABLE_ROOT_TESTS="
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"
       distro: "${BUILDKITE_AGENT_META_DATA_DISTRO}"

--- a/.hack/go.mod
+++ b/.hack/go.mod
@@ -12,4 +12,5 @@ go 1.11
 require (
 	github.com/awslabs/tc-redirect-tap v0.0.0-20220715050423-f2af44521093 // indirect
 	github.com/containernetworking/plugins v1.1.1 // indirect
+	github.com/kunalkushwaha/ltag v0.2.3 // indirect
 )

--- a/.hack/go.sum
+++ b/.hack/go.sum
@@ -393,6 +393,8 @@ github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kunalkushwaha/ltag v0.2.3 h1:5rwJiC1oQ/OiamZ8JNCHQGUe7OkHTFrRtyNon3VYPok=
+github.com/kunalkushwaha/ltag v0.2.3/go.mod h1:w1hVMWOh870f+WAv/UIoZAy0bHCbPP4+W6JxNcPUiQA=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,8 @@ DISABLE_ROOT_TESTS?=1
 DOCKER_IMAGE_TAG?=latest
 EXTRAGOARGS:=
 FIRECRACKER_DIR=build/firecracker
-FIRECRACKER_TARGET?=x86_64-unknown-linux-musl
+arch=$(shell uname -m)
+FIRECRACKER_TARGET?=$(arch)-unknown-linux-musl
 
 FC_TEST_DATA_PATH?=testdata
 FC_TEST_BIN_PATH:=$(FC_TEST_DATA_PATH)/bin
@@ -28,7 +29,6 @@ UID = $(shell id -u)
 GID = $(shell id -g)
 
 firecracker_version=v1.0.0
-arch=$(shell uname -m)
 
 # The below files are needed and can be downloaded from the internet
 release_url=https://github.com/firecracker-microvm/firecracker/releases/download/$(firecracker_version)/firecracker-$(firecracker_version)-$(arch).tgz
@@ -75,7 +75,7 @@ unit-tests: $(testdata_objects)
 	DISABLE_ROOT_TESTS=$(DISABLE_ROOT_TESTS) go test -short ./... $(EXTRAGOARGS)
 
 all-tests: $(testdata_objects)
-	DISABLE_ROOT_TESTS=$(DISABLE_ROOT_TESTS) go test ./... $(EXTRAGOARGS)
+	DISABLE_ROOT_TESTS=$(DISABLE_ROOT_TESTS) go test -v ./... $(EXTRAGOARGS)
 
 generate build clean::
 	go $@ $(EXTRAGOARGS)

--- a/machine.go
+++ b/machine.go
@@ -24,6 +24,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -64,6 +65,9 @@ type SeccompConfig struct {
 // ErrAlreadyStarted signifies that the Machine has already started and cannot
 // be started again.
 var ErrAlreadyStarted = errors.New("firecracker: machine already started")
+
+// ErrGraceShutdown signifies that the Machine will shutdown gracefully and SendCtrlAltDelete is unable to send
+var ErrGraceShutdown = errors.New("Shutdown gracefully: SendCtrlAltDelete is not supported if the arch is ARM64")
 
 type MMDSVersion string
 
@@ -456,7 +460,10 @@ func (m *Machine) Start(ctx context.Context) error {
 // Shutdown requests a clean shutdown of the VM by sending CtrlAltDelete on the virtual keyboard
 func (m *Machine) Shutdown(ctx context.Context) error {
 	m.logger.Debug("Called machine.Shutdown()")
-	return m.sendCtrlAltDel(ctx)
+	if runtime.GOARCH != "arm64" {
+		return m.sendCtrlAltDel(ctx)
+	}
+	return ErrGraceShutdown
 }
 
 // Wait will wait until the firecracker process has finished.  Wait is safe to

--- a/machine_test.go
+++ b/machine_test.go
@@ -234,6 +234,7 @@ func TestJailerMicroVMExecution(t *testing.T) {
 			ChrootStrategy: NewNaiveChrootStrategy(vmlinuxPath),
 			Stdout:         logFd,
 			Stderr:         logFd,
+			CgroupVersion:  "2",
 		},
 		FifoLogWriter: fw,
 	}

--- a/machine_test.go
+++ b/machine_test.go
@@ -27,6 +27,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -864,8 +865,10 @@ func TestStopVMMCleanup(t *testing.T) {
 
 func testShutdown(ctx context.Context, t *testing.T, m *Machine) {
 	err := m.Shutdown(ctx)
-	if err != nil {
-		t.Errorf("machine.Shutdown() failed: %s", err)
+	if runtime.GOARCH == "arm64" {
+		assert.ErrorIs(t, err, ErrGraceShutdown)
+	} else {
+		assert.NoError(t, err, "machine.Shutdown() failed")
 	}
 }
 

--- a/network_test.go
+++ b/network_test.go
@@ -253,7 +253,7 @@ func testNetworkMachineCNI(t *testing.T, useConfFile bool) {
 	}
 	fctesting.RequiresRoot(t)
 
-	cniBinPath := []string{"/opt/cni/bin", testDataBin}
+	cniBinPath := []string{"testdata/bin", testDataBin}
 
 	dir, err := ioutil.TempDir("", fsSafeTestName.Replace(t.Name()))
 	require.NoError(t, err)

--- a/network_test.go
+++ b/network_test.go
@@ -20,6 +20,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -344,7 +345,9 @@ func testNetworkMachineCNI(t *testing.T, useConfFile bool) {
 
 			assert.FileExists(t, expectedCacheDirPath, "CNI cache dir doesn't exist after vm startup")
 
-			testPing(t, vmIP, 3, 5*time.Second)
+			if runtime.GOARCH != "arm64" {
+				testPing(t, vmIP, 3, 5*time.Second)
+			}
 
 			require.NoError(t, m.StopVMM(), "failed to stop machine")
 			waitCtx, waitCancel := context.WithTimeout(ctx, 3*time.Second)
@@ -405,7 +408,6 @@ func newCNIMachine(t *testing.T,
 		MachineCfg: models.MachineConfiguration{
 			VcpuCount:  Int64(2),
 			MemSizeMib: Int64(256),
-			Smt:        Bool(true),
 		},
 		Drives: []models.Drive{
 			{


### PR DESCRIPTION
Signed-off-by: Vaishnavi Vejella <vvejella@amazon.com>

*Issue #[462](https://github.com/firecracker-microvm/firecracker-go-sdk/issues/462):*
While trying to perform ARM integration test against firecracker-go-sdk, **SendCtrlAltDel** is not supported on ARM64. 
**TestJailerMicroVMExecution** is failed to start VMM and Firecracker was not able to create an API socket and also the
**testPing** is not supported when running the test on multiple VM's. 

*Description of changes:* 
If the architecture is ARM, we must send a log message and warn that we are unable to perform **sendCtrlAltDel** (API) on aarch64, then call StopVMM. 
Modified the Jailer Config by specifying cgroups as v2 in TestJailerMicroVMExecution to `CgroupVersion: "2"` and by
Skipping the **testPing**, we can consider this test is not applicable or supported by ARM.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
